### PR TITLE
Disable Prettier for JS/TS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ const config = {
   env: {
     browser: true,
     es2020: true,
-    node: true,
+    node: true
   },
 
   /**
@@ -30,16 +30,16 @@ const config = {
    * @type {string[]}
    */
   extends: [
-    'standard-with-typescript',
     'standard-react',
+    'standard-with-typescript',
     'plugin:import/errors',
     'plugin:import/typescript',
     'plugin:import/warnings',
-    'plugin:jsx-a11y/recommended',
-    'plugin:prettier/recommended',
-    'prettier',
-    'prettier/react',
-    'prettier/standard',
+    'plugin:jsx-a11y/recommended'
+    // 'plugin:prettier/recommended',
+    // 'prettier',
+    // 'prettier/react',
+    // 'prettier/standard',
   ],
 
   /**
@@ -49,7 +49,7 @@ const config = {
   globals: {
     __PATH_PREFIX__: true,
     Atomics: 'readonly',
-    SharedArrayBuffer: 'readonly',
+    SharedArrayBuffer: 'readonly'
   },
 
   /**
@@ -65,11 +65,11 @@ const config = {
   parserOptions: {
     ecmaFeatures: {
       impliedStrict: true,
-      jsx: true,
+      jsx: true
     },
     ecmaVersion: 2020,
     project: './tsconfig.json',
-    sourceType: 'module',
+    sourceType: 'module'
   },
 
   /**
@@ -87,8 +87,8 @@ const config = {
    */
   settings: {
     react: {
-      version: 'detect',
-    },
+      version: 'detect'
+    }
   },
 
   overrides: [
@@ -106,8 +106,8 @@ const config = {
        */
       extends: [
         'plugin:@typescript-eslint/recommended',
-        'plugin:@typescript-eslint/recommended-requiring-type-checking',
-        'prettier/@typescript-eslint',
+        'plugin:@typescript-eslint/recommended-requiring-type-checking'
+        // 'prettier/@typescript-eslint',
       ],
 
       /**
@@ -134,10 +134,10 @@ const config = {
         'react/prop-types': 'off',
         '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
         '@typescript-eslint/explicit-function-return-type': ['error'],
-        '@typescript-eslint/strict-boolean-expressions': 'off',
-      },
-    },
-  ],
+        '@typescript-eslint/strict-boolean-expressions': 'off'
+      }
+    }
+  ]
 }
 
 module.exports = config

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ const config = {
   env: {
     browser: true,
     es2020: true,
-    node: true
+    node: true,
   },
 
   /**
@@ -35,7 +35,7 @@ const config = {
     'plugin:import/errors',
     'plugin:import/typescript',
     'plugin:import/warnings',
-    'plugin:jsx-a11y/recommended'
+    'plugin:jsx-a11y/recommended',
     // 'plugin:prettier/recommended',
     // 'prettier',
     // 'prettier/react',
@@ -49,7 +49,7 @@ const config = {
   globals: {
     __PATH_PREFIX__: true,
     Atomics: 'readonly',
-    SharedArrayBuffer: 'readonly'
+    SharedArrayBuffer: 'readonly',
   },
 
   /**
@@ -65,11 +65,11 @@ const config = {
   parserOptions: {
     ecmaFeatures: {
       impliedStrict: true,
-      jsx: true
+      jsx: true,
     },
     ecmaVersion: 2020,
     project: './tsconfig.json',
-    sourceType: 'module'
+    sourceType: 'module',
   },
 
   /**
@@ -82,13 +82,17 @@ const config = {
    */
   plugins: ['jsx-a11y', 'react'],
 
+  rules: {
+    'comma-dangle': ['error', 'always-multiline'],
+  },
+
   /**
    * @see https://eslint.org/docs/user-guide/configuring#adding-shared-settings
    */
   settings: {
     react: {
-      version: 'detect'
-    }
+      version: 'detect',
+    },
   },
 
   overrides: [
@@ -106,7 +110,7 @@ const config = {
        */
       extends: [
         'plugin:@typescript-eslint/recommended',
-        'plugin:@typescript-eslint/recommended-requiring-type-checking'
+        'plugin:@typescript-eslint/recommended-requiring-type-checking',
         // 'prettier/@typescript-eslint',
       ],
 
@@ -134,10 +138,10 @@ const config = {
         'react/prop-types': 'off',
         '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
         '@typescript-eslint/explicit-function-return-type': ['error'],
-        '@typescript-eslint/strict-boolean-expressions': 'off'
-      }
-    }
-  ]
+        '@typescript-eslint/strict-boolean-expressions': 'off',
+      },
+    },
+  ],
 }
 
 module.exports = config

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "prettier.quoteProps": "consistent",
+  "prettier.requireConfig": true,
+  "prettier.singleQuote": true,
+  "prettier.semi": false,
+  "prettier.trailingComma": "all",
+  "prettier.arrowParens": "always",
+  "prettier.endOfLine": "lf",
+  "prettier.printWidth": 100
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,7 +8,6 @@ type IndexProps = {
 }
 
 const Index: FC<IndexProps> = ({ data }) => {
-  // eslint-disable-next-line prettier/prettier
   return <div>Hello {data?.site?.siteMetadata?.name ?? 'world'}!</div>
 }
 


### PR DESCRIPTION
Prettier doesn't yet understand optional chaining or the nullish coalescing operator, and those are far more important for a good Gatsby+TS codebase than nicer formatting is.

Re-enable Prettier for JS/TS when it does.